### PR TITLE
feat: add visual feedback while processing tldr.chat request

### DIFF
--- a/src/main/core.cljs
+++ b/src/main/core.cljs
@@ -24,8 +24,17 @@
             (u/md-link? line-content))
       (p/let [link       (u/extract-link line-content)
               uuid-child (:uuid (ls/insert-block block-uuid
-                                               "processing: calling tldr.chat..."))
-              result     (tldr/summarize-url (trim link))]
+                                                 "processing: calling tldr.chat..."))
+              loading    (atom ["." ".." "..." "...." "..." ".."])
+              interval   (js/setInterval
+                          #(do
+                             (ls/update-block uuid-child
+                                              (str "processing: calling tldr.chat" (first @loading)))
+                             (swap! loading (fn [curr]
+                                              (conj (vec (rest curr)) (first curr)))))
+                          500)
+              result     (tldr/summarize-url (trim link))
+              _         (js/clearInterval interval)]
         (handle-summary-result uuid-child result))
       (ls/show-msg ":logseq-summarize/error content is not a link" "error"))))
 

--- a/src/main/tldr.cljs
+++ b/src/main/tldr.cljs
@@ -40,6 +40,7 @@
     (devlog "get-summary response - status:" status "body:" body)
     (cond
       (>= status 500) (e/error->response status body)
+      (= status 404) {:status 404 :body body}
       (= status 200) {:status 200 :body (process-body body)}
       :else {:status 202})))
 
@@ -55,8 +56,10 @@
           _         (devlog "Post response:" post-resp)
           result    (get-summary url)]
     (devlog "Current result:" result)
-    (if (= (:status result) 200)
-      result
+    (cond
+      (= (:status result) 404) {:status 404 :body (:body result)}
+      (= (:status result) 200) result
+      :else
       (do
         (devlog "not ready yet, retrying...")
         (-> (p/delay api-timeout)


### PR DESCRIPTION
When the user makes a call to tldr.chat, they don't know if it's being processed since it's async and processes in the background. Added visual feedback by animating dots in the "processing" message to indicate active processing.

The animation cycles through different dot patterns:
- processing: calling tldr.chat.
- processing: calling tldr.chat..
- processing: calling tldr.chat...
- processing: calling tldr.chat....

The animation continues until tldr.chat returns a response, providing clear visual feedback that the request is being handled.

fixed: #21
fixed: #23